### PR TITLE
Change phase voltages to int16

### DIFF
--- a/sensor_format.md
+++ b/sensor_format.md
@@ -135,9 +135,9 @@ The AC data includes voltage and phase information for the AC electricity, which
 
 | Field           | Size    | Type     | Description                        |
 | --------------- | ------- | -------- | ---------------------------------- |
-| Phase 1 Voltage | 2 bytes | `uint16` | AC voltage measured for phase 1    |
-| Phase 2 Voltage | 2 bytes | `uint16` | AC voltage measured for phase 2    |
-| Phase 3 Voltage | 2 bytes | `uint16` | AC voltage measured for phase 3    |
+| Phase 1 Voltage | 2 bytes | `int16`  | AC voltage measured for phase 1    |
+| Phase 2 Voltage | 2 bytes | `int16`  | AC voltage measured for phase 2    |
+| Phase 3 Voltage | 2 bytes | `int16`  | AC voltage measured for phase 3    |
 | Freqency (Hz)   | 2 bytes | `uint16` | AC frequency measured (all phases) |
 | Phase 2 degrees | 2 bytes | `uint16` | Degrees from phase 1 of phase 2    |
 | Phase 3 degrees | 2 bytes | `uint16` | Degrees from phase 1 of phase 3    |


### PR DESCRIPTION
See : https://github.com/flaviut/emporia-vue2-reversing/issues/1#issuecomment-977171995

The voltages are the only values that are a 1:1 match when parsed as int16. It would be logical to parse it as such.